### PR TITLE
'entered', 'reversed' trigger element with a top position <= 0 not triggering

### DIFF
--- a/scrollpoints.js
+++ b/scrollpoints.js
@@ -66,7 +66,7 @@ var Scrollpoints = (function (undefined) {
         var reversed = overrideReversed === undefined ? e.reversed : overrideReversed;
 
         if (reversed) {
-            return !e.done && windowTopPos() <= elementBegin(e.element) - e.offset;
+            return !e.done && ((windowTopPos() <= elementBegin(e.element) - e.offset) || windowTopPos() === 0);
         }
         return !e.done && windowBottomPos() >= elementEnd(e.element) + e.offset;
     };

--- a/test/index.html
+++ b/test/index.html
@@ -6,14 +6,18 @@
 	<link rel="stylesheet" href="main.css">
 </head>
 <body>
-
-	<section class="mega-height blue">Scroll down!</section>
+	<header class="nano-height cornflowerblue">
+		<p><b>Scroll down &darr;</b></p>
+		<p>I turn <span class="linen">linen</span> when I'm entering from below</p>
+		<p>I turn <span class="deeppink">deeppink</span> when I'm entered from below and my top position is less than or equal to zero</p>
+	</header>
+	<section class="mega-height cornflowerblue"></section>
 	<section class="mini-height">
-        <p>I will turn red when fully visible</p>
-        <p>and blue when 300px inside of the screen</p>
-        <p>I turn yellow when you scroll too far and I start to leave the screen.</p>
-        <p>When I start leaving the screen at the bottom edge, I will turn red again.</p>
-        <p>You can repeat the toggling between yellow and red as often as you want by scrolling up and down, but I won't turn blue again.</p>
+        <p>I will turn <span class="red">red</span> when fully visible</p>
+        <p>and <span class="cyan">cyan</span> when 300px inside of the screen</p>
+        <p>I turn <span class="yellow">yellow</span> when you scroll too far and I start to leave the screen.</p>
+        <p>When I start leaving the screen at the bottom edge, I will turn <span class="red">red</span> again.</p>
+        <p>You can repeat the toggling between <span class="yellow">yellow</span> and <span class="red">red</span> as often as you want by scrolling up and down, but I won't turn <span class="cyan">cyan</span> again.</p>
         <div class="absolute">
             Nested absolute positioning.
             Will move to the left when fully visible.
@@ -25,7 +29,24 @@
     <script>
     document.addEventListener('DOMContentLoaded', function () {
 
-        var sections = document.getElementsByTagName('section');
+        var sections = document.getElementsByTagName('section'),
+			header = document.getElementsByTagName('header')[0];
+
+	    Scrollpoints.add(header, function(elem) {
+		    elem.style.backgroundColor = 'deeppink';
+	    }, {
+		    when: 'entered',
+		    reversed: true,
+		    once: false
+	    });
+
+	    Scrollpoints.add(header, function(elem) {
+		    elem.style.backgroundColor = 'linen';
+	    }, {
+		    when: 'entering',
+		    reversed: true,
+		    once: false
+	    });
 
         Scrollpoints.add(sections[1], function(elem) {
             elem.style.backgroundColor = 'red';

--- a/test/main.css
+++ b/test/main.css
@@ -24,6 +24,11 @@ html, body {
 	position: relative;	
 }
 
+.nano-height {
+	height: 60px;
+	position: relative;
+}
+
 .absolute {
 	position: absolute;	
 	top: 30px;	
@@ -44,12 +49,10 @@ html, body {
 	SOME RANDOM COLORS
 */
 
-.blue {
-	background-color: #4E8EAD;
-}
-.red {
-	background-color: #B34848;
-}
-.green {
-	background-color: #3D6D43;
-}
+.cornflowerblue { background-color: cornflowerblue; }
+.red { background-color: red; }
+.darkgreen { background-color: darkgreen; }
+.deeppink { background-color: deeppink; }
+.linen { background-color: linen; }
+.cyan { background-color: cyan; }
+.yellow { background-color: yellow; }


### PR DESCRIPTION
# Why this PR

I found myself with an edge case where I could have elements with a top position less than or equal to zero. In these cases a 'reversed' 'entered' event will never be triggered. 
## What could work

Setting a negative offset should be ok, but makes the solution a little messy when the Scrollpoint's are added dynamically, as you'd have to write additional code to check the coordinates of the element and then adjust offset accordingly.
## Code change

So I ended up letting a reversed/entered event trigger if the scroll position was at it's utmost limit in that direction which seems logical to me (maybe only me)
## Tests

I've added a test case to the manual test document to verify the behaviour. (Sorry played with a couple of tiny things in the css, if you mind, I'm happy to revert it)

I look forward to your feedback/merge if I'm lucky. cheers. :yum:
